### PR TITLE
fix libva dependencies for libva2 (Ubuntu 18.04)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,7 @@ Pre-Depends: dpkg (>= 1.15.6)
 Depends: ${shlibs:Depends}, ${misc:Depends},
 	xdg-utils,
 	chromium-codecs-ffmpeg-extra (= ${binary:Version}) | chromium-codecs-ffmpeg (= ${binary:Version})
-Recommends: chromium-browser-l10n, libva1, libva-x11-1
+Recommends: chromium-browser-l10n, libva2 | libva1, libva-x11-2 | libva-x11-1, libva-wayland2 | libva-wayland1
 Suggests: webaccounts-chromium-extension,
 	unity-chromium-extension,
 	chromiumflashplugin


### PR DESCRIPTION
As for added ```libva-wayaland2 | libva-wayland1``` dependecy, I'm not sure that it's needed, but probably it will help today or one other day.